### PR TITLE
Update to TypeDoc 0.1.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "typedoc": "^0.0.4"
+    "typedoc": "^0.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Grunt plugin points to TypeDoc 0.0.4, the latest version (with a lot of changes) is 0.1.0. Maybe you could set the dependency to ^0.1 so it automatically updates to upcoming versions.
