### PR TITLE
Allow flags to be set with boolean values

### DIFF
--- a/tasks/typedoc.js
+++ b/tasks/typedoc.js
@@ -7,8 +7,12 @@ module.exports = function (grunt) {
 		var args = [];
 		for (var key in options) {
 			if (options.hasOwnProperty(key)) {
-				args.push('--' + key);
-				args.push(options[key]);
+				if (options[key] === true) {
+					args.push('--' + key);
+				} else if (options[key] !== false) {
+					args.push('--' + key);
+					args.push(options[key]);
+				}
 			}
 		}
 		for (var i = 0; i < this.filesSrc.length; i++) {


### PR DESCRIPTION
TypeDoc like TypeScript takes several command line arguments that don't have a value. Those currently cannot be set using grunt-typedoc. Let's simply take all options with a boolean value as flags:

```
typedoc: {
    build: {
        options: {
            module: 'commonjs',
            out: 'doc/',
            name: 'My documentation',
            target: 'es5',
            excludeExternals: true,
            noLib: false
        },
        src: 'src/**/*.ts'
    }
},
```
