### PR TITLE
Fixes the method by which the location of typedoc's executable is locate...

### DIFF
--- a/tasks/typedoc.js
+++ b/tasks/typedoc.js
@@ -22,8 +22,8 @@ module.exports = function (grunt) {
 		var winExt = /^win/.test(process.platform) ? '.cmd' : '';
 
 		var done = this.async();
-		var executable = path.resolve(__dirname, '..', 'node_modules', '.bin', 'typedoc' + winExt);
-
+		var executable = path.resolve(require.resolve('typedoc/package.json'), '..', '..', '.bin', 'typedoc' + winExt);
+		
 		var child = child_process.spawn(executable, args, {
 			stdio: 'inherit',
 			env: process.env


### PR DESCRIPTION
Fixes #4.

By using require.resolve to locate typedoc's package.json, we can reliably find the root directory of typedoc.  Then we ascend up a directory, descend into .bin, and we've found typedoc's executable.