### PR TITLE
ignore boolean option values

### DIFF
--- a/tasks/typedoc.js
+++ b/tasks/typedoc.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
 		for (var key in options) {
 			if (options.hasOwnProperty(key)) {
 				args.push('--' + key);
-				if (!!options[key]) {
+				if (typeof(options[key]) !== 'boolean') {
 					args.push(options[key]);
 				}
 			}


### PR DESCRIPTION
## Description
#### Steps to Reproduce

``` javascript
{
  options: {
    excludeExternals: true
  }
}
```
#### Current Result

`--excludeExternals true` is passed as typedoc flag, which cannot be interpreted
#### Expected Result

Adds the CLI flag `--excludeExternals` without any argument
## Workaround

Setting `excludeExternals` to `false` helps as workaround, but I'd expect it to (also) accept `true`.
