### PR TITLE
Implement boolean option flags and change TypeDoc path strategy

### DIFF
--- a/tasks/typedoc.js
+++ b/tasks/typedoc.js
@@ -6,9 +6,9 @@ module.exports = function (grunt) {
 
 		var args = [];
 		for (var key in options) {
-			if (options.hasOwnProperty(key) && (typeof options[key] !== "boolean" || options[key])) {
+			if (options.hasOwnProperty(key) && (typeof options[key] !== 'boolean' || options[key])) {
 				args.push('--' + key);
-				if (typeof options[key] !== "boolean" && !!options[key]) {
+				if (typeof options[key] !== 'boolean' && !!options[key]) {
 					args.push(options[key]);
 				}
 			}
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 		try {
 			typedoc = require.resolve('../../typedoc/package.json');
 		} catch(e) {
-			typedoc = require.resolve('typedoc/package.json')
+			typedoc = require.resolve('typedoc/package.json');
 		}
 
 		var winExt = /^win/.test(process.platform) ? '.cmd' : '';

--- a/tasks/typedoc.js
+++ b/tasks/typedoc.js
@@ -6,9 +6,9 @@ module.exports = function (grunt) {
 
 		var args = [];
 		for (var key in options) {
-			if (options.hasOwnProperty(key)) {
+			if (options.hasOwnProperty(key) && (typeof options[key] !== "boolean" || options[key])) {
 				args.push('--' + key);
-				if (!!options[key]) {
+				if (typeof options[key] !== "boolean" && !!options[key]) {
 					args.push(options[key]);
 				}
 			}
@@ -20,11 +20,18 @@ module.exports = function (grunt) {
 		// lazy init
 		var path = require('path');
 		var child_process = require('child_process');
+		var typedoc;
+
+		try {
+			typedoc = require.resolve('../../typedoc/package.json');
+		} catch(e) {
+			typedoc = require.resolve('typedoc/package.json')
+		}
 
 		var winExt = /^win/.test(process.platform) ? '.cmd' : '';
 
 		var done = this.async();
-		var executable = path.resolve(require.resolve('typedoc/package.json'), '..', '..', '.bin', 'typedoc' + winExt);
+		var executable = path.resolve(typedoc, '..', '..', '.bin', 'typedoc' + winExt);
 		
 		var child = child_process.spawn(executable, args, {
 			stdio: 'inherit',


### PR DESCRIPTION
This PR implements boolean option flags as suggested in #8 and it suggests a different strategy for finding the TypeDoc executable. If TypeDoc is installed in the same project directory as Grunt-TypeDoc, this peer TypeDoc instance is used instead of the child TypeDoc which is included in Grunt-TypeDoc. This allows faster adoption of new TypeDoc versions without the need to wait for an updated version of Grunt-TypeDoc (just update TypeDoc in your project). If TypeDoc is not installed as peer the old behavior will be used instead.